### PR TITLE
Implement core game state and travel loop

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -1,1 +1,4 @@
-[]
+[
+  {"id": "deer", "name": "Deer", "speed": 5, "yield": 40},
+  {"id": "rabbit", "name": "Rabbit", "speed": 8, "yield": 5}
+]

--- a/data/items.json
+++ b/data/items.json
@@ -1,1 +1,6 @@
-[]
+[
+  {"id": "oxen", "name": "Oxen", "price": 40},
+  {"id": "food", "name": "Food", "price": 0.2},
+  {"id": "clothes", "name": "Clothes", "price": 10},
+  {"id": "bullets", "name": "Bullets", "price": 2}
+]

--- a/data/landmarks.json
+++ b/data/landmarks.json
@@ -1,1 +1,7 @@
-[]
+[
+  {"mile": 0, "name": "Fort McPherson"},
+  {"mile": 120, "name": "Red River"},
+  {"mile": 300, "name": "Fort Edmonton"},
+  {"mile": 550, "name": "Rocky Pass"},
+  {"mile": 800, "name": "Pacific Camp"}
+]

--- a/main.js
+++ b/main.js
@@ -1,13 +1,21 @@
+import { startNewGame, continueGame } from './state/GameState.js';
+import { showTravelScreen } from './ui/TravelScreen.js';
+
 function init() {
   const newGameBtn = document.getElementById('new-game');
   const continueBtn = document.getElementById('continue');
 
   newGameBtn.addEventListener('click', () => {
-    console.log('New Game selected');
+    startNewGame('Farmer');
+    showTravelScreen();
   });
 
   continueBtn.addEventListener('click', () => {
-    console.log('Continue selected');
+    if (continueGame()) {
+      showTravelScreen();
+    } else {
+      alert('No saved game');
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "canadian-trail",
   "version": "0.0.1",
   "description": "Canadian Trail static web project",
+  "type": "module",
   "scripts": {
     "dev": "python3 -m http.server 5173 || python -m http.server 5173 || npx http-server -p 5173",
     "test": "node tests/run.js"

--- a/state/GameState.js
+++ b/state/GameState.js
@@ -1,0 +1,143 @@
+import { travelDay, restDay } from '../systems/travel.js';
+
+export let state = null;
+let rng = Math.random;
+
+const professionFunds = {
+  Farmer: 500,
+  Carpenter: 700,
+  Banker: 1200
+};
+
+const defaultParty = [
+  { name: 'Merri-Ellen', age: 30, health: 100 },
+  { name: 'Mike', age: 32, health: 100 },
+  { name: 'Ros', age: 9, health: 100 },
+  { name: 'Jess', age: 6, health: 100 },
+  { name: 'Martha', age: 3, health: 100 },
+  { name: 'Rusty', age: 1, health: 100 }
+];
+
+const storage = typeof localStorage !== 'undefined'
+  ? localStorage
+  : (() => {
+      const mem = {};
+      return {
+        getItem: (k) => (k in mem ? mem[k] : null),
+        setItem: (k, v) => {
+          mem[k] = String(v);
+        },
+        removeItem: (k) => {
+          delete mem[k];
+        }
+      };
+    })();
+
+function saveGame() {
+  if (state) {
+    storage.setItem('gameState', JSON.stringify(state));
+  }
+}
+
+function createRNG(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    state.rngSeed = s;
+    return s / 4294967296;
+  };
+}
+
+function computeSeason(dateStr) {
+  const d = new Date(dateStr);
+  const m = d.getMonth() + 1;
+  if (m <= 2 || m === 12) return 'Winter';
+  if (m <= 5) return 'Spring';
+  if (m <= 8) return 'Summer';
+  return 'Fall';
+}
+
+export function startNewGame(profession = 'Farmer', seed = Date.now()) {
+  const funds = professionFunds[profession] || professionFunds.Farmer;
+  state = {
+    day: 1,
+    date: '1848-03-01',
+    season: 'Spring',
+    profession,
+    inventory: {
+      food: 100,
+      money: funds
+    },
+    party: defaultParty.map((p) => ({ ...p })),
+    milesTraveled: 0,
+    milesRemaining: 2000,
+    pace: 'Steady',
+    rations: 'Normal',
+    log: [],
+    rngSeed: seed
+  };
+  rng = createRNG(seed);
+  addLog('Game started', true);
+  saveGame();
+  return state;
+}
+
+export function continueGame() {
+  const data = storage.getItem('gameState');
+  if (!data) return null;
+  state = JSON.parse(data);
+  rng = createRNG(state.rngSeed);
+  return state;
+}
+
+export function setPace(pace) {
+  state.pace = pace;
+  saveGame();
+}
+
+export function setRations(rations) {
+  state.rations = rations;
+  saveGame();
+}
+
+export function addLog(message, skipSave = false) {
+  state.log.push(message);
+  if (!skipSave) saveGame();
+}
+
+function incrementDate(days) {
+  const d = new Date(state.date);
+  d.setDate(d.getDate() + days);
+  state.date = d.toISOString().slice(0, 10);
+  state.day += days;
+  state.season = computeSeason(state.date);
+}
+
+export function advanceDay() {
+  const before = state.milesTraveled;
+  travelDay(state);
+  const moved = state.milesTraveled - before;
+  incrementDate(1);
+  addLog(`Traveled ${moved} miles.`, true);
+  saveGame();
+}
+
+export function rest(days = 1) {
+  for (let i = 0; i < days; i++) {
+    restDay(state);
+    incrementDate(1);
+    addLog('Rested.', true);
+  }
+  saveGame();
+}
+
+export function random() {
+  const val = rng();
+  saveGame();
+  return val;
+}
+
+export function getState() {
+  return state;
+}
+

--- a/styles.css
+++ b/styles.css
@@ -22,3 +22,33 @@ button {
 button:focus {
   outline: 3px solid #000;
 }
+#travel-screen {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+#progress-bar {
+  width: 100%;
+  height: 10px;
+  background: #ccc;
+  margin: 0.5rem 0;
+}
+
+#progress {
+  height: 100%;
+  width: 0%;
+  background: green;
+}
+
+#party-list {
+  list-style: none;
+  padding: 0;
+}
+
+#log {
+  border: 1px solid #999;
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}

--- a/systems/travel.js
+++ b/systems/travel.js
@@ -1,0 +1,59 @@
+export function travelDay(state) {
+  const paceMultiplier = {
+    Steady: 1,
+    Strenuous: 1.2,
+    Grueling: 1.35
+  };
+  const rationRates = {
+    Meager: 1.5,
+    Normal: 2.0,
+    Generous: 2.5
+  };
+  const paceHealth = {
+    Steady: 0,
+    Strenuous: -1,
+    Grueling: -2
+  };
+
+  const miles = Math.round(15 * paceMultiplier[state.pace]);
+  state.milesTraveled += miles;
+  state.milesRemaining = Math.max(0, state.milesRemaining - miles);
+
+  const foodNeeded = rationRates[state.rations] * state.party.length;
+  state.inventory.food -= foodNeeded;
+
+  let healthDelta = paceHealth[state.pace];
+  if (state.inventory.food <= 0) {
+    healthDelta -= 2;
+    state.inventory.food = 0;
+  }
+
+  state.party.forEach((m) => {
+    m.health = clamp(m.health + healthDelta, 0, 100);
+  });
+}
+
+export function restDay(state) {
+  const rationRates = {
+    Meager: 1.5,
+    Normal: 2.0,
+    Generous: 2.5
+  };
+  const foodNeeded = rationRates[state.rations] * state.party.length;
+  state.inventory.food -= foodNeeded;
+  if (state.inventory.food <= 0) {
+    state.inventory.food = 0;
+    state.party.forEach((m) => {
+      m.health = clamp(m.health - 2, 0, 100);
+    });
+  } else {
+    state.party.forEach((m) => {
+      m.health = clamp(m.health + 1, 0, 100);
+    });
+  }
+}
+
+function clamp(val, min, max) {
+  return Math.max(min, Math.min(max, val));
+}
+

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,3 +1,60 @@
 #!/usr/bin/env node
-console.log('Test stub');
-process.exit(0);
+import assert from 'assert';
+
+if (typeof global.localStorage === 'undefined') {
+  global.localStorage = (() => {
+    const store = {};
+    return {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => {
+        store[k] = String(v);
+      },
+      removeItem: (k) => {
+        delete store[k];
+      }
+    };
+  })();
+}
+
+const GS = await import('../state/GameState.js');
+const {
+  startNewGame,
+  random,
+  setPace,
+  setRations,
+  advanceDay,
+  continueGame,
+  getState
+} = GS;
+
+// RNG determinism
+startNewGame('Farmer', 123);
+const seq1 = [random(), random(), random()];
+startNewGame('Farmer', 123);
+const seq2 = [random(), random(), random()];
+assert.deepStrictEqual(seq1, seq2, 'RNG sequence mismatch');
+
+// Ration consumption & pace health
+startNewGame('Farmer', 456);
+const st = getState();
+st.inventory.food = 100;
+setRations('Normal');
+setPace('Grueling');
+advanceDay();
+const expectedFood = 100 - 2 * st.party.length;
+assert.strictEqual(Math.round(st.inventory.food), expectedFood, 'Food consumption wrong');
+st.party.forEach((m) => {
+  assert.strictEqual(m.health, 98, 'Health penalty wrong');
+});
+
+// Autosave/load
+startNewGame('Farmer', 789);
+setPace('Strenuous');
+advanceDay();
+const snapshot = JSON.parse(JSON.stringify(getState()));
+const curr = getState();
+curr.pace = 'Steady';
+const loaded = continueGame();
+assert.deepStrictEqual(loaded, snapshot, 'Loaded state mismatch');
+
+console.log('All tests passed.');

--- a/ui/TravelScreen.js
+++ b/ui/TravelScreen.js
@@ -1,0 +1,100 @@
+import { getState, setPace, setRations, advanceDay, rest } from '../state/GameState.js';
+
+export function showTravelScreen() {
+  const state = getState();
+  document.body.innerHTML = '';
+  const main = document.createElement('main');
+  main.id = 'travel-screen';
+  main.innerHTML = `
+    <section id="top">
+      <div id="date"></div>
+      <div id="progress-bar"><div id="progress"></div></div>
+      <div id="settings">
+        <label>Pace
+          <select id="pace">
+            <option value="Steady">Steady</option>
+            <option value="Strenuous">Strenuous</option>
+            <option value="Grueling">Grueling</option>
+          </select>
+        </label>
+        <label>Rations
+          <select id="rations">
+            <option value="Meager">Meager</option>
+            <option value="Normal">Normal</option>
+            <option value="Generous">Generous</option>
+          </select>
+        </label>
+      </div>
+    </section>
+    <section id="party">
+      <h2>Party</h2>
+      <ul id="party-list"></ul>
+    </section>
+    <section id="inventory">
+      <h2>Inventory</h2>
+      <p>Food: <span id="food"></span> lbs</p>
+    </section>
+    <section id="log-section">
+      <h2>Log</h2>
+      <div id="log" tabindex="0"></div>
+    </section>
+    <section id="actions">
+      <button id="travel-btn">Travel one day</button>
+      <button id="rest-btn">Rest</button>
+      <button id="hunt-btn" disabled>Hunt</button>
+      <button id="map-btn" disabled>Map</button>
+    </section>
+  `;
+  document.body.appendChild(main);
+
+  const paceSel = main.querySelector('#pace');
+  const rationSel = main.querySelector('#rations');
+  paceSel.value = state.pace;
+  rationSel.value = state.rations;
+
+  paceSel.addEventListener('change', (e) => {
+    setPace(e.target.value);
+    render();
+  });
+  rationSel.addEventListener('change', (e) => {
+    setRations(e.target.value);
+    render();
+  });
+  main.querySelector('#travel-btn').addEventListener('click', () => {
+    advanceDay();
+    render();
+  });
+  main.querySelector('#rest-btn').addEventListener('click', () => {
+    const days = parseInt(prompt('Rest how many days?', '1'), 10) || 1;
+    rest(days);
+    render();
+  });
+
+  function render() {
+    const s = getState();
+    main.querySelector('#date').textContent = `Day ${s.day} — ${s.date} (${s.season})`;
+    const total = s.milesTraveled + s.milesRemaining;
+    const pct = total ? (s.milesTraveled / total) * 100 : 0;
+    main.querySelector('#progress').style.width = pct + '%';
+
+    const list = main.querySelector('#party-list');
+    list.innerHTML = '';
+    s.party.forEach((m) => {
+      const li = document.createElement('li');
+      li.textContent = `${m.name} (${m.age}) — ${Math.round(m.health)}`;
+      list.appendChild(li);
+    });
+    main.querySelector('#food').textContent = Math.round(s.inventory.food);
+    const logDiv = main.querySelector('#log');
+    logDiv.innerHTML = '';
+    s.log.slice(-20).forEach((entry) => {
+      const p = document.createElement('div');
+      p.textContent = entry;
+      logDiv.appendChild(p);
+    });
+    logDiv.scrollTop = logDiv.scrollHeight;
+  }
+
+  render();
+}
+


### PR DESCRIPTION
## Summary
- Add deterministic GameState with default party, funds, autosave and seeded RNG
- Implement travel system for pace, ration consumption, health drift and starvation
- Create Travel screen UI with controls, party and inventory display, and event log
- Populate starter data JSON and add Node tests for RNG and state handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689772ecc92083209093393eb608ed1d