### PR TITLE
Implement branching event engine with UI and tests

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,1 +1,93 @@
-[]
+[
+  {
+    "id": "spring-storm",
+    "weight": 3,
+    "conditions": { "season": ["Spring"] },
+    "intro": "Spring winds carry dark clouds.",
+    "stages": [
+      {
+        "text": "Do you set camp or keep moving?",
+        "choices": [
+          { "id": "camp", "text": "Make camp", "next": "camp_wait" },
+          { "id": "move", "text": "Keep moving", "next": "move_on" }
+        ]
+      },
+      {
+        "id": "camp_wait",
+        "text": "You hunker down as the sky rumbles.",
+        "followupRoll": [
+          { "chance": 0.6, "effects": [{"type":"time","days":1}], "textOnRoll": "The storm passes overnight." },
+          { "chance": 0.4, "effects": [{"type":"inventory","key":"food","delta":-10},{"type":"health","target":"party","delta":-5}], "textOnRoll": "Rain floods the camp." }
+        ]
+      },
+      {
+        "id": "move_on",
+        "text": "The path grows muddy.",
+        "choices": [
+          { "id": "steady", "text": "Walk carefully", "effects": [{"type":"time","days":1}] },
+          { "id": "rush", "text": "Hurry through", "effects": [{"type":"health","target":"party","delta":-2}] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "river-warning",
+    "weight": 2,
+    "conditions": { "season": ["Summer","Fall"] },
+    "intro": "A scout warns of swift river currents ahead.",
+    "stages": [
+      {
+        "text": "Do you heed the warning?",
+        "choices": [
+          { "id": "detour", "text": "Take a long detour", "effects": [{"type":"mapFlag","key":"riverDetour","value":true},{"type":"distance","delta":-15},{"type":"riskBuff","key":"riverAccident","value":"-10%"}] },
+          { "id": "ignore", "text": "Ignore it", "effects": [{"type":"riskBuff","key":"riverAccident","value":"+10%"}] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "mountain-trader",
+    "weight": 2,
+    "conditions": { "season": ["Summer","Fall"] },
+    "intro": "A wandering trader offers supplies.",
+    "stages": [
+      {
+        "text": "He'll swap 20 lbs of food for 10 bullets.",
+        "choices": [
+          { "id": "trade", "text": "Trade food", "effects": [{"type":"inventory","key":"food","delta":-20},{"type":"inventory","key":"bullets","delta":10}] },
+          { "id": "decline", "text": "Decline", "effects": [{"type":"morale","delta":-1}] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "snake-in-grass",
+    "weight": 1,
+    "conditions": { "season": ["Summer"] },
+    "intro": "Ros spots something in the tall grass.",
+    "stages": [
+      {
+        "text": "A snake strikes at Ros.",
+        "choices": [
+          { "id": "help", "text": "Try to help", "effects": [{"type":"mortality","memberId":"ros","epitaphKey":"death_ros_snakebite"}] },
+          { "id": "run", "text": "Everyone runs", "effects": [{"type":"morale","delta":-2}] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "river-mishap",
+    "weight": 1,
+    "conditions": { "season": ["Spring","Summer"] },
+    "intro": "Jess slips near the river bank.",
+    "stages": [
+      {
+        "text": "Do you grab her?",
+        "choices": [
+          { "id": "grab", "text": "Grab her", "effects": [{"type":"health","target":"member","memberId":"jess","delta":-20}] },
+          { "id": "tooSlow", "text": "Too slow!", "effects": [{"type":"mortality","memberId":"jess","epitaphKey":"death_jess_river"}] }
+        ]
+      }
+    ]
+  }
+]

--- a/systems/eventEngine.js
+++ b/systems/eventEngine.js
@@ -1,0 +1,174 @@
+export function eligibleEvents(state, events = []) {
+  return events.filter((ev) => {
+    const c = ev.conditions || {};
+    if (c.mileMin != null && state.milesTraveled < c.mileMin) return false;
+    if (c.mileMax != null && state.milesTraveled > c.mileMax) return false;
+    if (c.season && c.season.length && !c.season.map((s)=>s.toLowerCase()).includes(state.season.toLowerCase())) return false;
+    if (c.terrain && c.terrain.length && c.terrain.indexOf(state.terrain) === -1) return false;
+    if (c.requiresStatus) {
+      const statuses = new Set(state.statuses || []);
+      for (const st of c.requiresStatus) if (!statuses.has(st)) return false;
+    }
+    if (c.excludesStatus) {
+      const statuses = new Set(state.statuses || []);
+      for (const st of c.excludesStatus) if (statuses.has(st)) return false;
+    }
+    if (c.requiresFlags) {
+      const flags = state.mapFlags || {};
+      for (const k in c.requiresFlags) if (flags[k] !== c.requiresFlags[k]) return false;
+    }
+    if (c.minPartyHealthAvg != null) {
+      const avg = state.party.reduce((a, m) => a + m.health, 0) / state.party.length;
+      if (avg < c.minPartyHealthAvg) return false;
+    }
+    return true;
+  });
+}
+
+export function pickWeighted(rng, list, weightKey = 'weight') {
+  const total = list.reduce((s, it) => s + (it[weightKey] || 0), 0);
+  let r = rng() * total;
+  for (const it of list) {
+    r -= it[weightKey] || 0;
+    if (r <= 0) return it;
+  }
+  return list[list.length - 1];
+}
+
+export function startEvent(state, event) {
+  const firstStage = event.stages[0];
+  state.activeEvent = { id: event.id, stageId: firstStage.id || 0, vars: {} };
+  state.meta = state.meta || { daysSinceLastEvent: 0 };
+  state.meta.daysSinceLastEvent = 0;
+  return state;
+}
+
+export function applyEffects(state, effects = [], ctx = {}) {
+  const log = ctx.log || (() => {});
+  for (const eff of effects) {
+    switch (eff.type) {
+      case 'resource':
+      case 'inventory': {
+        if (!state.inventory) state.inventory = {};
+        const prev = state.inventory[eff.key] || 0;
+        state.inventory[eff.key] = prev + (eff.delta || 0);
+        log(`${eff.delta >= 0 ? 'Gained' : 'Lost'} ${Math.abs(eff.delta)} ${eff.key}.`);
+        break;
+      }
+      case 'money': {
+        if (!state.inventory) state.inventory = {};
+        state.inventory.money = (state.inventory.money || 0) + (eff.delta || 0);
+        log(`${eff.delta >= 0 ? 'Gained' : 'Lost'} $${Math.abs(eff.delta)}.`);
+        break;
+      }
+      case 'health': {
+        const delta = eff.delta || 0;
+        const clamp = (v) => Math.max(0, Math.min(100, v));
+        if (eff.target === 'member') {
+          const m = state.party.find((p) => p.id === eff.memberId);
+          if (m) {
+            m.health = clamp(m.health + delta);
+            log(`${m.name}'s health ${delta >= 0 ? 'improved' : 'dropped'} ${Math.abs(delta)}.`);
+          }
+        } else if (eff.target === 'party' || eff.target === 'all') {
+          state.party.forEach((m) => {
+            m.health = clamp(m.health + delta);
+          });
+          log(`Party health ${delta >= 0 ? 'improved' : 'dropped'} ${Math.abs(delta)}.`);
+        }
+        break;
+      }
+      case 'status': {
+        const { action, status, target, memberId } = eff;
+        const apply = (m) => {
+          m.statuses = m.statuses || [];
+          if (action === 'add' && !m.statuses.includes(status)) m.statuses.push(status);
+          if (action === 'remove') m.statuses = m.statuses.filter((s) => s !== status);
+        };
+        if (target === 'member') {
+          const m = state.party.find((p) => p.id === memberId);
+          if (m) apply(m);
+        } else if (target === 'party' || target === 'all') {
+          state.party.forEach(apply);
+        }
+        break;
+      }
+      case 'time': {
+        const days = eff.days || 0;
+        const d = new Date(state.date);
+        d.setDate(d.getDate() + days);
+        state.date = d.toISOString().slice(0, 10);
+        state.day += days;
+        const m = d.getMonth() + 1;
+        if (m <= 2 || m === 12) state.season = 'Winter';
+        else if (m <= 5) state.season = 'Spring';
+        else if (m <= 8) state.season = 'Summer';
+        else state.season = 'Fall';
+        log(`Lost ${days} days.`);
+        break;
+      }
+      case 'distance': {
+        const miles = eff.delta || 0;
+        state.milesTraveled += miles;
+        state.milesRemaining = Math.max(0, state.milesRemaining - miles);
+        log(`Distance changed by ${miles} miles.`);
+        break;
+      }
+      case 'morale': {
+        state.morale = (state.morale || 0) + (eff.delta || 0);
+        log(`Morale ${eff.delta >= 0 ? 'rose' : 'fell'} ${Math.abs(eff.delta)}.`);
+        break;
+      }
+      case 'mapFlag': {
+        state.mapFlags = state.mapFlags || {};
+        state.mapFlags[eff.key] = eff.value;
+        break;
+      }
+      case 'riskBuff': {
+        state.risks = state.risks || {};
+        state.risks[eff.key] = eff.value;
+        break;
+      }
+      case 'mortality': {
+        let member = null;
+        if (eff.memberId === 'random') {
+          if (state.party.length) {
+            const idx = Math.floor((ctx.rng ? ctx.rng() : Math.random()) * state.party.length);
+            member = state.party[idx];
+          }
+        } else {
+          member = state.party.find((p) => p.id === eff.memberId);
+        }
+        if (member) {
+          state.party = state.party.filter((m) => m !== member);
+          state.epitaphs = state.epitaphs || {};
+          const key = eff.epitaphKey || `death_${member.id}_${eff.cause || 'unknown'}`;
+          state.epitaphs[member.id] = key;
+          log(`${member.name} has died.`);
+        }
+        break;
+      }
+    }
+  }
+  return state;
+}
+
+export function nextStage(state, stageOrId, ctx = {}) {
+  const events = ctx.events || {};
+  const event = events[state.activeEvent.id];
+  if (!event) return state;
+  let stage = null;
+  if (typeof stageOrId === 'object') stage = stageOrId;
+  else {
+    stage = event.stages.find((s) => s.id === stageOrId) || event.stages[stageOrId];
+  }
+  if (!stage) return state;
+  state.activeEvent.stageId = stage.id || event.stages.indexOf(stage);
+  if (stage.text) ctx.log && ctx.log(stage.text);
+  if (stage.effects) applyEffects(state, stage.effects, ctx);
+  if (!stage.choices && !stage.followupRoll) {
+    ctx.endEvent && ctx.endEvent();
+  }
+  return state;
+}
+

--- a/tests/run.js
+++ b/tests/run.js
@@ -24,8 +24,13 @@ const {
   setRations,
   advanceDay,
   continueGame,
-  getState
+  getState,
+  setActiveEvent
 } = GS;
+
+const EE = await import('../systems/eventEngine.js');
+const { eligibleEvents, pickWeighted, applyEffects, startEvent } = EE;
+import events from '../data/events.json' assert { type: 'json' };
 
 // RNG determinism
 startNewGame('Farmer', 123);
@@ -56,5 +61,70 @@ const curr = getState();
 curr.pace = 'Steady';
 const loaded = continueGame();
 assert.deepStrictEqual(loaded, snapshot, 'Loaded state mismatch');
+
+// eligibleEvents filters
+const evts = [{ id: 'test', weight: 1, conditions: { mileMin: 0, mileMax: 100, season: ['Spring'] } }];
+const es = eligibleEvents({ milesTraveled: 50, season: 'Spring', party: [{ health: 100 }] }, evts);
+assert.strictEqual(es.length, 1, 'Event should be eligible');
+const es2 = eligibleEvents({ milesTraveled: 150, season: 'Spring', party: [{ health: 100 }] }, evts);
+assert.strictEqual(es2.length, 0, 'Event mile filter failed');
+const es3 = eligibleEvents({ milesTraveled: 50, season: 'Winter', party: [{ health: 100 }] }, evts);
+assert.strictEqual(es3.length, 0, 'Event season filter failed');
+
+// pickWeighted deterministic
+const rng = (() => { let s = 123; return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };})();
+const picked = pickWeighted(rng, [{ id: 'a', weight: 1 }, { id: 'b', weight: 3 }]);
+assert.strictEqual(picked.id, 'b', 'Weighted pick failed');
+
+// applyEffects basic resources
+const testState = {
+  inventory: { food: 0, money: 0 },
+  party: [{ id: 'p', name: 'P', health: 50, statuses: [] }],
+  milesTraveled: 0,
+  milesRemaining: 100,
+  date: '1848-03-01',
+  day: 1,
+  season: 'Spring'
+};
+applyEffects(testState, [
+  { type: 'inventory', key: 'food', delta: 10 },
+  { type: 'money', delta: 5 },
+  { type: 'health', target: 'member', memberId: 'p', delta: 5 },
+  { type: 'time', days: 2 },
+  { type: 'distance', delta: 20 },
+  { type: 'morale', delta: 1 }
+], { log: () => {} });
+assert.strictEqual(testState.inventory.food, 10, 'Inventory change failed');
+assert.strictEqual(testState.inventory.money, 5, 'Money change failed');
+assert.strictEqual(testState.party[0].health, 55, 'Health change failed');
+assert.strictEqual(testState.day, 3, 'Time change failed');
+assert.strictEqual(testState.milesTraveled, 20, 'Distance change failed');
+assert.strictEqual(testState.milesRemaining, 80, 'Distance remaining failed');
+assert.strictEqual(testState.morale, 1, 'Morale change failed');
+
+// mortality effect
+const deathState = {
+  party: [{ id: 'ros', name: 'Ros', health: 100, statuses: [] }],
+  epitaphs: {},
+  inventory: {},
+  date: '1848-03-01',
+  day: 1,
+  season: 'Spring',
+  milesTraveled: 0,
+  milesRemaining: 0
+};
+applyEffects(deathState, [{ type: 'mortality', memberId: 'ros', epitaphKey: 'death_ros_snakebite' }], { log: () => {} });
+assert.strictEqual(deathState.party.length, 0, 'Mortality did not remove member');
+assert.strictEqual(deathState.epitaphs.ros, 'death_ros_snakebite', 'Epitaph not set');
+
+// save/load activeEvent
+startNewGame('Farmer', 999);
+const state = getState();
+startEvent(state, events[0]);
+setActiveEvent(state.activeEvent);
+const stageId = state.activeEvent.stageId;
+const resumed = continueGame();
+assert.ok(resumed.activeEvent, 'Active event not persisted');
+assert.strictEqual(resumed.activeEvent.stageId, stageId, 'Active event stage mismatch');
 
 console.log('All tests passed.');

--- a/ui/EventModal.js
+++ b/ui/EventModal.js
@@ -1,0 +1,66 @@
+import { chooseEventChoice } from '../state/GameState.js';
+
+export function showEventModal(event, stage, onClose) {
+  const overlay = document.createElement('div');
+  overlay.id = 'event-modal';
+  overlay.setAttribute('role', 'dialog');
+  overlay.tabIndex = -1;
+
+  const box = document.createElement('div');
+  box.className = 'modal-box';
+
+  const text = document.createElement('p');
+  text.textContent = stage.text || '';
+  box.appendChild(text);
+
+  const btnWrap = document.createElement('div');
+  const buttons = [];
+  if (stage.choices) {
+    stage.choices.forEach((ch, idx) => {
+      const btn = document.createElement('button');
+      btn.textContent = `${idx + 1}. ${ch.text}`;
+      btn.dataset.choice = ch.id;
+      btn.addEventListener('click', () => {
+        chooseEventChoice(ch.id);
+        close();
+      });
+      btnWrap.appendChild(btn);
+      buttons.push(btn);
+    });
+  } else if (stage.followupRoll) {
+    const btn = document.createElement('button');
+    btn.textContent = 'Continue';
+    btn.addEventListener('click', () => {
+      chooseEventChoice(null);
+      close();
+    });
+    btnWrap.appendChild(btn);
+    buttons.push(btn);
+  }
+  box.appendChild(btnWrap);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+
+  function close() {
+    document.body.removeChild(overlay);
+    onClose && onClose();
+  }
+
+  overlay.addEventListener('keydown', (e) => {
+    if (stage.choices) {
+      const idx = parseInt(e.key, 10) - 1;
+      if (idx >= 0 && idx < buttons.length) {
+        buttons[idx].click();
+      }
+    } else if (stage.followupRoll && e.key === 'Enter') {
+      buttons[0].click();
+    }
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      buttons[0].focus();
+    }
+  });
+
+  buttons[0] && buttons[0].focus();
+}
+

--- a/ui/TravelScreen.js
+++ b/ui/TravelScreen.js
@@ -1,4 +1,8 @@
 import { getState, setPace, setRations, advanceDay, rest } from '../state/GameState.js';
+import { showEventModal } from './EventModal.js';
+import events from '../data/events.json' assert { type: 'json' };
+
+const eventMap = Object.fromEntries(events.map((e) => [e.id, e]));
 
 export function showTravelScreen() {
   const state = getState();
@@ -55,19 +59,23 @@ export function showTravelScreen() {
   paceSel.addEventListener('change', (e) => {
     setPace(e.target.value);
     render();
+    checkEvent();
   });
   rationSel.addEventListener('change', (e) => {
     setRations(e.target.value);
     render();
+    checkEvent();
   });
   main.querySelector('#travel-btn').addEventListener('click', () => {
     advanceDay();
     render();
+    checkEvent();
   });
   main.querySelector('#rest-btn').addEventListener('click', () => {
     const days = parseInt(prompt('Rest how many days?', '1'), 10) || 1;
     rest(days);
     render();
+    checkEvent();
   });
 
   function render() {
@@ -93,8 +101,24 @@ export function showTravelScreen() {
       logDiv.appendChild(p);
     });
     logDiv.scrollTop = logDiv.scrollHeight;
+
+    const disabled = !!s.activeEvent;
+    main.querySelector('#travel-btn').disabled = disabled;
+    main.querySelector('#rest-btn').disabled = disabled;
+  }
+
+  function checkEvent() {
+    const s = getState();
+    if (!s.activeEvent) return;
+    const ev = eventMap[s.activeEvent.id];
+    const stage = ev.stages.find((st, i) => (st.id ?? i) === s.activeEvent.stageId);
+    showEventModal(ev, stage, () => {
+      render();
+      checkEvent();
+    });
   }
 
   render();
+  checkEvent();
 }
 


### PR DESCRIPTION
## Summary
- Add event engine with eligibility filtering, weighted selection, effect application, and stage progression
- Persist active events and new morale/risk fields in GameState; auto-roll events during travel
- Introduce accessible Event modal and integrate into travel screen; include sample events with trades, risk buffs, and character deaths
- Expand test suite for event logic, effects, mortality, and save/load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689775d8d0248320aa5cf68653e34a18