### PR TITLE
Add asset manifest and loader

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,34 @@
+{
+  "ui": {
+    "icon_food": {
+      "src": "assets/img/ui/icon_food.png",
+      "src2x": "assets/img/ui/icon_food@2x.png",
+      "w": 16,
+      "h": 16
+    }
+  },
+  "scenes": {
+    "title": {
+      "src": "assets/img/scene/title.png",
+      "src2x": "assets/img/scene/title@2x.png",
+      "w": 320,
+      "h": 200
+    },
+    "travel": {
+      "src": "assets/img/scene/travel.png",
+      "src2x": "assets/img/scene/travel@2x.png",
+      "w": 320,
+      "h": 200
+    }
+  },
+  "sprites": {
+    "deer": {
+      "src": "assets/img/sprites/deer.png",
+      "src2x": "assets/img/sprites/deer@2x.png",
+      "frameWidth": 32,
+      "frameHeight": 32,
+      "frames": 4,
+      "fps": 8
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div id="title-bg" class="scene-bg"></div>
   <main id="title-screen">
     <h1>Canadian Trail</h1>
     <nav aria-label="Main menu">

--- a/main.js
+++ b/main.js
@@ -1,7 +1,20 @@
 import { startNewGame, continueGame } from './state/GameState.js';
 import { showTravelScreen } from './ui/TravelScreen.js';
+import { loadAssets, getImage, getMeta } from './systems/assets.js';
 
-function init() {
+async function init() {
+  await loadAssets('data/manifest.json');
+
+  const bgContainer = document.getElementById('title-bg');
+  const bgImg = getImage('scenes.title');
+  const bgMeta = getMeta('scenes.title');
+  if (bgContainer && bgImg && bgMeta) {
+    bgContainer.style.width = bgMeta.w + 'px';
+    bgContainer.style.height = bgMeta.h + 'px';
+    bgImg.classList.add('pixelated');
+    bgContainer.appendChild(bgImg);
+  }
+
   const newGameBtn = document.getElementById('new-game');
   const continueBtn = document.getElementById('continue');
 

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@ body {
   align-items: center;
   justify-content: center;
   background: #fff;
+  position: relative;
 }
 
 #title-screen {
@@ -51,4 +52,19 @@ button:focus {
   max-height: 150px;
   overflow-y: auto;
   padding: 0.5rem;
+}
+
+.img-slot {
+  display: inline-block;
+}
+
+.scene-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+
+.pixelated {
+  image-rendering: pixelated;
 }

--- a/systems/assets.js
+++ b/systems/assets.js
@@ -1,0 +1,84 @@
+export const AssetRegistry = { images: {} };
+
+export async function loadAssets(manifestPath = 'data/manifest.json') {
+  let manifest;
+  try {
+    const res = await fetch(manifestPath);
+    manifest = await res.json();
+  } catch (err) {
+    console.error('Failed to load manifest', err);
+    return;
+  }
+  const dpr = window.devicePixelRatio || 1;
+  for (const [category, entries] of Object.entries(manifest)) {
+    AssetRegistry.images[category] = {};
+    for (const [key, meta] of Object.entries(entries)) {
+      const copy = { ...meta };
+      const src = dpr >= 2 && meta.src2x ? meta.src2x : meta.src;
+      try {
+        const img = await loadImage(src, copy);
+        AssetRegistry.images[category][key] = { img, meta: copy, placeholder: false };
+      } catch (e) {
+        const placeholder = generatePlaceholder(copy, `${category}.${key}`);
+        AssetRegistry.images[category][key] = { img: placeholder, meta: copy, placeholder: true };
+      }
+    }
+  }
+}
+
+function loadImage(src, meta) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      img.width = meta.w || meta.frameWidth || img.naturalWidth;
+      img.height = meta.h || meta.frameHeight || img.naturalHeight;
+      resolve(img);
+    };
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+function generatePlaceholder(meta, label) {
+  const w = meta.w || meta.frameWidth || 64;
+  const h = meta.h || meta.frameHeight || 64;
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  const size = 8;
+  for (let y = 0; y < h; y += size) {
+    for (let x = 0; x < w; x += size) {
+      ctx.fillStyle = (x / size + y / size) % 2 === 0 ? '#bbb' : '#ddd';
+      ctx.fillRect(x, y, size, size);
+    }
+  }
+  ctx.fillStyle = '#000';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = Math.floor(h / 4) + 'px sans-serif';
+  ctx.fillText(label.split('.').pop(), w / 2, h / 2);
+  return canvas;
+}
+
+export function getImage(path) {
+  const [category, key] = path.split('.');
+  const asset = AssetRegistry.images[category]?.[key];
+  if (!asset) return null;
+  if (asset.img instanceof HTMLCanvasElement) {
+    const c = document.createElement('canvas');
+    c.width = asset.img.width;
+    c.height = asset.img.height;
+    const ctx = c.getContext('2d');
+    ctx.drawImage(asset.img, 0, 0);
+    return c;
+  }
+  return asset.img.cloneNode(true);
+}
+
+export function getMeta(path) {
+  const [category, key] = path.split('.');
+  const asset = AssetRegistry.images[category]?.[key];
+  if (!asset) return null;
+  return { ...asset.meta, placeholder: asset.placeholder };
+}

--- a/systems/sprite.js
+++ b/systems/sprite.js
@@ -1,0 +1,30 @@
+export class Sprite {
+  constructor(img, meta) {
+    this.img = img;
+    this.meta = meta;
+    this.placeholder = meta.placeholder || false;
+    this.frame = 0;
+    this.acc = 0;
+  }
+
+  update(dt) {
+    const frameTime = 1000 / (this.meta.fps || 1);
+    this.acc += dt;
+    while (this.acc >= frameTime) {
+      this.acc -= frameTime;
+      this.frame = (this.frame + 1) % this.meta.frames;
+    }
+  }
+
+  draw(ctx, x, y) {
+    ctx.imageSmoothingEnabled = false;
+    const fw = this.meta.frameWidth;
+    const fh = this.meta.frameHeight;
+    const sx = this.frame * fw;
+    ctx.drawImage(this.img, sx, 0, fw, fh, x, y, fw, fh);
+    if (this.placeholder) {
+      ctx.strokeStyle = 'rgba(255,0,0,0.4)';
+      ctx.strokeRect(Math.floor(x) + 0.5, Math.floor(y) + 0.5, fw - 1, fh - 1);
+    }
+  }
+}

--- a/ui/TravelScreen.js
+++ b/ui/TravelScreen.js
@@ -1,12 +1,27 @@
 import { getState, setPace, setRations, advanceDay, rest } from '../state/GameState.js';
 import { showEventModal } from './EventModal.js';
 import events from '../data/events.json' assert { type: 'json' };
+import { getImage, getMeta } from '../systems/assets.js';
 
 const eventMap = Object.fromEntries(events.map((e) => [e.id, e]));
 
 export function showTravelScreen() {
   const state = getState();
   document.body.innerHTML = '';
+
+  const bg = document.createElement('div');
+  bg.id = 'travel-bg';
+  bg.className = 'scene-bg';
+  const bgImg = getImage('scenes.travel');
+  const bgMeta = getMeta('scenes.travel');
+  if (bgImg && bgMeta) {
+    bg.style.width = bgMeta.w + 'px';
+    bg.style.height = bgMeta.h + 'px';
+    bgImg.classList.add('pixelated');
+    bg.appendChild(bgImg);
+  }
+  document.body.appendChild(bg);
+
   const main = document.createElement('main');
   main.id = 'travel-screen';
   main.innerHTML = `
@@ -36,7 +51,7 @@ export function showTravelScreen() {
     </section>
     <section id="inventory">
       <h2>Inventory</h2>
-      <p>Food: <span id="food"></span> lbs</p>
+      <p><span id="food-icon" class="img-slot"></span> Food: <span id="food"></span> lbs</p>
     </section>
     <section id="log-section">
       <h2>Log</h2>
@@ -50,6 +65,16 @@ export function showTravelScreen() {
     </section>
   `;
   document.body.appendChild(main);
+
+  const foodIcon = main.querySelector('#food-icon');
+  const foodImg = getImage('ui.icon_food');
+  const foodMeta = getMeta('ui.icon_food');
+  if (foodIcon && foodImg && foodMeta) {
+    foodIcon.style.width = foodMeta.w + 'px';
+    foodIcon.style.height = foodMeta.h + 'px';
+    foodImg.classList.add('pixelated');
+    foodIcon.appendChild(foodImg);
+  }
 
   const paceSel = main.querySelector('#pace');
   const rationSel = main.querySelector('#rations');
@@ -121,4 +146,3 @@ export function showTravelScreen() {
   render();
   checkEvent();
 }
-


### PR DESCRIPTION
## Summary
- add data/manifest.json to map UI icons, scene backgrounds, and sprites
- implement asset loader with canvas placeholders and retrieval helpers
- introduce sprite class for animating sprite sheets
- wire title and travel screens to use asset images and backgrounds
- style image slots and scene backgrounds with pixelated rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689778f97a5083208b4e4de5ca2aa508