### PR TITLE
Add landmarks progression and shop system

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,6 +1,8 @@
 [
-  {"id": "oxen", "name": "Oxen", "price": 40},
-  {"id": "food", "name": "Food", "price": 0.2},
-  {"id": "clothes", "name": "Clothes", "price": 10},
-  {"id": "bullets", "name": "Bullets", "price": 2}
+  {"id": "food", "name": "Food", "unit": "lbs", "basePrice": 0.2},
+  {"id": "bullets", "name": "Bullets", "unit": "box", "basePrice": 2},
+  {"id": "medicine", "name": "Medicine", "unit": "bottle", "basePrice": 5},
+  {"id": "clothes", "name": "Clothes", "unit": "set", "basePrice": 10},
+  {"id": "spare_parts", "name": "Spare Parts", "unit": "ea", "basePrice": 15},
+  {"id": "oxen", "name": "Oxen", "unit": "head", "basePrice": 40}
 ]

--- a/data/landmarks.json
+++ b/data/landmarks.json
@@ -1,7 +1,18 @@
 [
-  {"mile": 0, "name": "Fort McPherson"},
-  {"mile": 120, "name": "Red River"},
-  {"mile": 300, "name": "Fort Edmonton"},
-  {"mile": 550, "name": "Rocky Pass"},
-  {"mile": 800, "name": "Pacific Camp"}
+  {"id":"independence","name":"Independence","mile":0,"services":{"shop":true},"talk":["The trail begins here."]},
+  {"id":"kansas_river","name":"Kansas River Crossing","mile":102,"services":{"river":true},"talk":["The water runs swift this spring."]},
+  {"id":"fort_kearny","name":"Fort Kearny","mile":318,"services":{"shop":true},"talk":["Supplies are dear out here."]},
+  {"id":"chimney_rock","name":"Chimney Rock","mile":554,"services":{},"talk":["That rock points the way west."]},
+  {"id":"fort_laramie","name":"Fort Laramie","mile":640,"services":{"shop":true},"talk":["Soldiers trade news for coffee."]},
+  {"id":"independence_rock","name":"Independence Rock","mile":800,"services":{},"talk":["Names of many travelers mark the stone."]},
+  {"id":"south_pass","name":"South Pass","mile":910,"services":{},"talk":["It's all downhill from here, they say."]},
+  {"id":"fort_bridger","name":"Fort Bridger","mile":1030,"services":{"shop":true},"talk":["Jim Bridger charges a pretty penny."]},
+  {"id":"soda_springs","name":"Soda Springs","mile":1130,"services":{},"talk":["Bubbles tickle the nose."]},
+  {"id":"fort_hall","name":"Fort Hall","mile":1170,"services":{"shop":true},"talk":["Trappers swap tall tales here."]},
+  {"id":"snake_river","name":"Snake River Crossing","mile":1400,"services":{"river":true},"talk":["Many wagons have tipped here."]},
+  {"id":"fort_boise","name":"Fort Boise","mile":1520,"services":{"shop":true},"talk":["The fort is barely more than a few huts."]},
+  {"id":"blue_mountains","name":"Blue Mountains","mile":1740,"services":{},"talk":["The climb taxes the teams."]},
+  {"id":"fort_walla_walla","name":"Fort Walla Walla","mile":1820,"services":{"shop":true},"talk":["Mission folk offer fresh bread."]},
+  {"id":"the_dalles","name":"The Dalles","mile":1900,"services":{"river":true,"shop":true},"talk":["You may raft from here if you dare."]},
+  {"id":"willamette_valley","name":"Willamette Valley","mile":2000,"services":{},"talk":["Green hills welcome the weary."]}
 ]

--- a/systems/eventEngine.js
+++ b/systems/eventEngine.js
@@ -110,6 +110,8 @@ export function applyEffects(state, effects = [], ctx = {}) {
       case 'distance': {
         const miles = eff.delta || 0;
         state.milesTraveled += miles;
+        state.progress = state.progress || { milesTraveled: state.milesTraveled, landmarkIndex: 0 };
+        state.progress.milesTraveled = state.milesTraveled;
         state.milesRemaining = Math.max(0, state.milesRemaining - miles);
         log(`Distance changed by ${miles} miles.`);
         break;

--- a/systems/landmarks.js
+++ b/systems/landmarks.js
@@ -1,0 +1,23 @@
+import landmarks from '../data/landmarks.json' assert { type: 'json' };
+
+export function getNextLandmark(state) {
+  return landmarks[state.progress.landmarkIndex] || null;
+}
+
+export function milesToNext(state) {
+  const next = getNextLandmark(state);
+  if (!next) return 0;
+  return Math.max(0, next.mile - state.progress.milesTraveled);
+}
+
+export function checkArrival(state) {
+  const index = state.progress.landmarkIndex;
+  const next = landmarks[index];
+  if (next && state.progress.milesTraveled >= next.mile) {
+    state.progress.landmarkIndex = index + 1;
+    return { arrived: true, landmark: next, index };
+  }
+  return { arrived: false, landmark: null, index };
+}
+
+export { landmarks };

--- a/systems/shop.js
+++ b/systems/shop.js
@@ -1,0 +1,62 @@
+import items from '../data/items.json' assert { type: 'json' };
+import { landmarks } from './landmarks.js';
+
+const itemsById = Object.fromEntries(items.map(i => [i.id, i]));
+const totalLandmarks = landmarks.length;
+
+function roundToCents(v) {
+  return Math.round(v * 100) / 100;
+}
+
+export function priceAt(landmarkIndex, basePrice) {
+  const inflation = 1 + 0.15 * (landmarkIndex / (totalLandmarks - 1));
+  return roundToCents(basePrice * inflation);
+}
+
+export function canBuy(state, itemId, qty) {
+  if (qty <= 0) return false;
+  const item = itemsById[itemId];
+  if (!item) return false;
+  const price = priceAt(state.activeLandmark.index, item.basePrice) * qty;
+  return state.inventory.money >= price;
+}
+
+export function canSell(state, itemId, qty) {
+  if (qty <= 0) return false;
+  const item = itemsById[itemId];
+  if (!item) return false;
+  const have = state.inventory[itemId] || 0;
+  return have >= qty;
+}
+
+export function applyPurchase(state, cart, log = () => {}) {
+  for (const { id, qty } of cart) {
+    if (qty <= 0) continue;
+    const item = itemsById[id];
+    if (!item) continue;
+    const price = priceAt(state.activeLandmark.index, item.basePrice) * qty;
+    if (state.inventory.money >= price) {
+      state.inventory.money = roundToCents(state.inventory.money - price);
+      state.inventory[id] = (state.inventory[id] || 0) + qty;
+      log(`Bought ${qty} ${item.unit} ${item.name} for $${price.toFixed(2)}`);
+    }
+  }
+}
+
+export function applySell(state, cart, log = () => {}) {
+  for (const { id, qty } of cart) {
+    if (qty <= 0) continue;
+    const item = itemsById[id];
+    if (!item) continue;
+    const have = state.inventory[id] || 0;
+    const sellQty = Math.min(qty, have);
+    if (sellQty > 0) {
+      const price = priceAt(state.activeLandmark.index, item.basePrice) * sellQty;
+      state.inventory.money = roundToCents(state.inventory.money + price);
+      state.inventory[id] = have - sellQty;
+      log(`Sold ${sellQty} ${item.unit} ${item.name} for $${price.toFixed(2)}`);
+    }
+  }
+}
+
+export { items };

--- a/systems/travel.js
+++ b/systems/travel.js
@@ -17,6 +17,8 @@ export function travelDay(state) {
 
   const miles = Math.round(15 * paceMultiplier[state.pace]);
   state.milesTraveled += miles;
+  state.progress = state.progress || { milesTraveled: 0, landmarkIndex: 0 };
+  state.progress.milesTraveled = state.milesTraveled;
   state.milesRemaining = Math.max(0, state.milesRemaining - miles);
 
   const foodNeeded = rationRates[state.rations] * state.party.length;

--- a/ui/LandmarkScreen.js
+++ b/ui/LandmarkScreen.js
@@ -1,0 +1,93 @@
+import { rest, addLog, closeLandmark } from '../state/GameState.js';
+import { random } from '../state/GameState.js';
+import { showShopScreen } from './ShopScreen.js';
+import { openRiverModal } from './RiverModal.js';
+
+export function showLandmarkScreen(landmark, onClose) {
+  const modal = document.createElement('div');
+  modal.id = 'landmark-modal';
+  modal.className = 'modal';
+  modal.setAttribute('role', 'dialog');
+  const talk = landmark.talk && landmark.talk.length
+    ? landmark.talk[Math.floor(random() * landmark.talk.length)]
+    : '';
+  modal.innerHTML = `
+    <h2>${landmark.name}</h2>
+    <p>Mile ${landmark.mile}</p>
+    <p id="landmark-talk">${talk}</p>
+    <div id="landmark-services"></div>
+    <div class="landmark-actions"></div>
+  `;
+  document.body.appendChild(modal);
+
+  const servicesDiv = modal.querySelector('#landmark-services');
+  const actionsDiv = modal.querySelector('.landmark-actions');
+
+  const buttons = [];
+  if (landmark.services.shop) {
+    const b = document.createElement('button');
+    b.textContent = 'Shop';
+    b.addEventListener('click', () => {
+      showShopScreen(landmark, () => {
+        modal.style.display = 'block';
+        trapFocus();
+      });
+      modal.style.display = 'none';
+    });
+    servicesDiv.appendChild(document.createTextNode('Shop available. '));
+    actionsDiv.appendChild(b); buttons.push(b);
+  }
+  if (landmark.services.river) {
+    const b = document.createElement('button');
+    b.textContent = 'River';
+    b.addEventListener('click', () => openRiverModal());
+    servicesDiv.appendChild(document.createTextNode('River nearby. '));
+    actionsDiv.appendChild(b); buttons.push(b);
+  }
+  const restBtn = document.createElement('button');
+  restBtn.textContent = 'Rest…';
+  restBtn.addEventListener('click', () => {
+    const days = Math.min(3, Math.max(1, parseInt(prompt('Rest how many days? (1-3)', '1'), 10) || 1));
+    rest(days);
+    addLog(`Rested ${days} day${days>1?'s':''} at ${landmark.name}.`, true);
+    alert(`Rested ${days} day${days>1?'s':''}.`);
+  });
+  actionsDiv.appendChild(restBtn); buttons.push(restBtn);
+
+  const leaveBtn = document.createElement('button');
+  leaveBtn.textContent = 'Leave';
+  leaveBtn.addEventListener('click', () => {
+    closeLandmark();
+    modal.remove();
+    onClose && onClose();
+  });
+  actionsDiv.appendChild(leaveBtn); buttons.push(leaveBtn);
+
+  function trapFocus() {
+    modal.focus();
+  }
+
+  modal.tabIndex = -1;
+  modal.addEventListener('keydown', (e) => {
+    const idx = parseInt(e.key, 10) - 1;
+    if (idx >= 0 && idx < buttons.length) {
+      buttons[idx].click();
+    }
+    if (e.key === 'Tab') {
+      const focusables = buttons;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        last.focus(); e.preventDefault();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        first.focus(); e.preventDefault();
+      }
+    }
+    if (e.key === 'Escape') {
+      leaveBtn.click();
+    }
+  });
+
+  trapFocus();
+  if (buttons.length) buttons[0].focus();
+}

--- a/ui/RiverModal.js
+++ b/ui/RiverModal.js
@@ -1,0 +1,3 @@
+export function openRiverModal() {
+  alert('River crossing not implemented yet.');
+}

--- a/ui/ShopScreen.js
+++ b/ui/ShopScreen.js
@@ -1,0 +1,124 @@
+import { getState, addLog } from '../state/GameState.js';
+import { priceAt, canBuy, canSell, applyPurchase, applySell, items } from '../systems/shop.js';
+
+export function showShopScreen(landmark, onClose) {
+  const state = getState();
+  const modal = document.createElement('div');
+  modal.id = 'shop-modal';
+  modal.className = 'modal';
+  modal.setAttribute('role', 'dialog');
+  modal.innerHTML = `
+    <h2>Shop</h2>
+    <table id="shop-table">
+      <thead><tr><th>Item</th><th>Price</th><th>Inventory</th><th>Qty</th></tr></thead>
+      <tbody></tbody>
+    </table>
+    <div id="shop-total">Total: $<span id="cart-total">0.00</span></div>
+    <div class="shop-actions">
+      <button id="buy-btn" disabled>Buy</button>
+      <button id="sell-btn" disabled>Sell</button>
+      <button id="close-shop">Back</button>
+    </div>
+  `;
+  document.body.appendChild(modal);
+
+  const tbody = modal.querySelector('tbody');
+  const inputs = {};
+
+  items.forEach(it => {
+    const price = priceAt(landmark.index, it.basePrice);
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${it.name}</td>
+      <td>$${price.toFixed(2)}</td>
+      <td class="inv">${state.inventory[it.id] || 0}</td>
+      <td><input type="number" min="0" value="0" step="1" id="qty-${it.id}"></td>
+    `;
+    tbody.appendChild(tr);
+    inputs[it.id] = tr.querySelector('input');
+    inputs[it.id].addEventListener('input', updateTotals);
+  });
+
+  const buyBtn = modal.querySelector('#buy-btn');
+  const sellBtn = modal.querySelector('#sell-btn');
+  const closeBtn = modal.querySelector('#close-shop');
+  const totalSpan = modal.querySelector('#cart-total');
+
+  function updateTotals() {
+    let buyTotal = 0;
+    let canBuyAll = true;
+    let canSellAll = true;
+    items.forEach(it => {
+      const qty = parseInt(inputs[it.id].value, 10) || 0;
+      const price = priceAt(landmark.index, it.basePrice) * qty;
+      if (qty > 0) {
+        if (!canBuy(state, it.id, qty)) canBuyAll = false;
+        if (!canSell(state, it.id, qty)) canSellAll = false;
+        buyTotal += price;
+      }
+    });
+    totalSpan.textContent = buyTotal.toFixed(2);
+    buyBtn.disabled = !canBuyAll || buyTotal <= 0;
+    sellBtn.disabled = !canSellAll;
+  }
+
+  buyBtn.addEventListener('click', () => {
+    const cart = [];
+    items.forEach(it => {
+      const qty = parseInt(inputs[it.id].value, 10) || 0;
+      if (qty > 0) cart.push({ id: it.id, qty });
+    });
+    applyPurchase(state, cart, addLog);
+    items.forEach(it => { inputs[it.id].value = 0; });
+    refreshInventory();
+    updateTotals();
+  });
+
+  sellBtn.addEventListener('click', () => {
+    const cart = [];
+    items.forEach(it => {
+      const qty = parseInt(inputs[it.id].value, 10) || 0;
+      if (qty > 0) cart.push({ id: it.id, qty });
+    });
+    applySell(state, cart, addLog);
+    items.forEach(it => { inputs[it.id].value = 0; });
+    refreshInventory();
+    updateTotals();
+  });
+
+  function refreshInventory() {
+    items.forEach(it => {
+      const row = inputs[it.id].closest('tr');
+      row.querySelector('.inv').textContent = state.inventory[it.id] || 0;
+    });
+  }
+
+  closeBtn.addEventListener('click', () => {
+    modal.remove();
+    onClose && onClose();
+  });
+
+  function trap(e) {
+    if (e.key === 'Tab') {
+      const focusables = Array.from(modal.querySelectorAll('button, input'));
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        last.focus();
+        e.preventDefault();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        first.focus();
+        e.preventDefault();
+      }
+    }
+    if (e.key === 'Escape') {
+      closeBtn.click();
+    }
+  }
+  modal.addEventListener('keydown', trap);
+
+  refreshInventory();
+  updateTotals();
+  const focusables = modal.querySelectorAll('button, input');
+  if (focusables.length) focusables[0].focus();
+}


### PR DESCRIPTION
## Summary
- Expand trail with ordered landmarks and mile-based arrival checks
- Introduce price-inflating shop with buy/sell logic and inventory tracking
- Add Landmark and Shop UIs with rest and river stubs plus travel screen indicator
- Persist landmark progress and validate via new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977f0e00188320ba5e259f3098815c