### PR TITLE
Use fetch JSON loader for cross-browser support

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,6 @@
       <button id="continue">Continue</button>
     </nav>
   </main>
-  <script type="module" src="main.js"></script>
+  <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,9 +1,11 @@
 import { startNewGame, continueGame } from './state/GameState.js';
 import { showTravelScreen } from './ui/TravelScreen.js';
 import { loadAssets, getImage, getMeta } from './systems/assets.js';
+import { loadJSON } from './systems/jsonLoader.js';
 
 async function init() {
-  await loadAssets('data/manifest.json');
+  const manifest = await loadJSON('./data/manifest.json', import.meta.url);
+  await loadAssets(manifest);
 
   const bgContainer = document.getElementById('title-bg');
   const bgImg = getImage('scenes.title');
@@ -32,4 +34,20 @@ async function init() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', init);
+function showInitError(e) {
+  console.error(e);
+  const banner = document.createElement('div');
+  banner.textContent = 'Failed to initialize: ' + e.message;
+  banner.style.position = 'fixed';
+  banner.style.top = '0';
+  banner.style.left = '0';
+  banner.style.right = '0';
+  banner.style.background = 'red';
+  banner.style.color = 'white';
+  banner.style.padding = '0.5em';
+  document.body.appendChild(banner);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  init().catch(showInitError);
+});

--- a/state/GameState.js
+++ b/state/GameState.js
@@ -1,6 +1,7 @@
 import { travelDay, restDay } from '../systems/travel.js';
 import { eligibleEvents, pickWeighted, startEvent as engineStartEvent, applyEffects, nextStage as engineNextStage } from '../systems/eventEngine.js';
-import events from '../data/events.json' assert { type: 'json' };
+import { loadJSON } from '../systems/jsonLoader.js';
+const events = await loadJSON('../data/events.json', import.meta.url);
 
 import { checkArrival, landmarks } from "../systems/landmarks.js";
 

--- a/systems/assets.js
+++ b/systems/assets.js
@@ -1,14 +1,6 @@
 export const AssetRegistry = { images: {} };
 
-export async function loadAssets(manifestPath = 'data/manifest.json') {
-  let manifest;
-  try {
-    const res = await fetch(manifestPath);
-    manifest = await res.json();
-  } catch (err) {
-    console.error('Failed to load manifest', err);
-    return;
-  }
+export async function loadAssets(manifest) {
   const dpr = window.devicePixelRatio || 1;
   for (const [category, entries] of Object.entries(manifest)) {
     AssetRegistry.images[category] = {};

--- a/systems/jsonLoader.js
+++ b/systems/jsonLoader.js
@@ -1,0 +1,11 @@
+export async function loadJSON(path, base = import.meta.url) {
+  const url = new URL(path, base);
+  if (url.protocol === 'file:') {
+    const fs = await import('fs/promises');
+    const text = await fs.readFile(url, 'utf-8');
+    return JSON.parse(text);
+  }
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to load JSON: ${url} (${res.status})`);
+  return await res.json();
+}

--- a/systems/landmarks.js
+++ b/systems/landmarks.js
@@ -1,4 +1,5 @@
-import landmarks from '../data/landmarks.json' assert { type: 'json' };
+import { loadJSON } from './jsonLoader.js';
+export const landmarks = await loadJSON('../data/landmarks.json', import.meta.url);
 
 export function getNextLandmark(state) {
   return landmarks[state.progress.landmarkIndex] || null;
@@ -20,4 +21,3 @@ export function checkArrival(state) {
   return { arrived: false, landmark: null, index };
 }
 
-export { landmarks };

--- a/systems/shop.js
+++ b/systems/shop.js
@@ -1,5 +1,6 @@
-import items from '../data/items.json' assert { type: 'json' };
+import { loadJSON } from './jsonLoader.js';
 import { landmarks } from './landmarks.js';
+export const items = await loadJSON('../data/items.json', import.meta.url);
 
 const itemsById = Object.fromEntries(items.map(i => [i.id, i]));
 const totalLandmarks = landmarks.length;
@@ -59,4 +60,3 @@ export function applySell(state, cart, log = () => {}) {
   }
 }
 
-export { items };

--- a/tests/run.js
+++ b/tests/run.js
@@ -31,7 +31,8 @@ const {
 
 const EE = await import('../systems/eventEngine.js');
 const { eligibleEvents, pickWeighted, applyEffects, startEvent } = EE;
-import events from '../data/events.json' assert { type: 'json' };
+import { loadJSON } from '../systems/jsonLoader.js';
+const events = await loadJSON('../data/events.json', import.meta.url);
 const LM = await import('../systems/landmarks.js');
 const { checkArrival, landmarks: lmData } = LM;
 const SH = await import('../systems/shop.js');

--- a/ui/TravelScreen.js
+++ b/ui/TravelScreen.js
@@ -1,6 +1,7 @@
 import { getState, setPace, setRations, advanceDay, rest } from '../state/GameState.js';
 import { showEventModal } from './EventModal.js';
-import events from '../data/events.json' assert { type: 'json' };
+import { loadJSON } from '../systems/jsonLoader.js';
+const events = await loadJSON('../data/events.json', import.meta.url);
 import { getNextLandmark, milesToNext, landmarks } from "../systems/landmarks.js";
 import { showLandmarkScreen } from "./LandmarkScreen.js";
 import { getImage, getMeta } from '../systems/assets.js';


### PR DESCRIPTION
## Summary
- Add `loadJSON` helper to fetch local JSON files across environments
- Bootstrap main with async init, manifest loading, and error banner
- Replace import assertions with loader in state, UI, shop, and landmark modules

## Testing
- `npm test`
- `npm run dev` *(fails: Address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6899e6649a208320997901e3573f55d0